### PR TITLE
Fix possible double-free of temporary indices buffer in compressMG1.c

### DIFF
--- a/lib/compressMG1.c
+++ b/lib/compressMG1.c
@@ -185,7 +185,6 @@ int _ctmCompressMesh_MG1(_CTMcontext * self)
   _ctmStreamWrite(self, (void *) "VERT", 4);
   if(!_ctmStreamWritePackedFloats(self, self->mVertices, self->mVertexCount * 3, 1))
   {
-    free((void *) indices);
     return CTM_FALSE;
   }
 


### PR DESCRIPTION
This appears to be a clear-cut case of accidentally calling `free` on a dangling pointer.

GCC reported:

```
compressMG1.c: In function ‘_ctmCompressMesh_MG1’: compressMG1.c:188:5: warning: pointer ‘indices_45’ may be used after ‘free’ [-Wuse-after-free]
  188 |     free((void *) indices);
      |     ^~~~~~~~~~~~~~~~~~~~~~
compressMG1.c:179:3: note: call to ‘free’ here
  179 |   free((void *) indices);
      |   ^~~~~~~~~~~~~~~~~~~~~~
```

and indeed, the conditional call to `free` removed in this PR appears a few lines after an unconditional `free` in

https://github.com/Danny02/OpenCTM/blob/91b3b71009ade4b036570526327a7e547fe43cbf/lib/compressMG1.c#L179
