### PR TITLE
Update to the current release of rply, 1.1.4

### DIFF
--- a/tools/ply.cpp
+++ b/tools/ply.cpp
@@ -167,7 +167,7 @@ void Import_PLY(const char * aFileName, Mesh * aMesh)
   state.mColorIdx = 0;
 
   // Open the PLY file
-  p_ply ply = ply_open(aFileName, NULL);
+  p_ply ply = ply_open(aFileName, NULL, 0, NULL);
   if(!ply)
     throw runtime_error("Unable to open PLY file.");
   if(!ply_read_header(ply))

--- a/tools/rply/LICENSE
+++ b/tools/rply/LICENSE
@@ -1,5 +1,5 @@
-RPly 1.01 license
-Copyright © 2003-2005 Diego Nehab.
+RPly 1.1.4 license
+Copyright © 2003-2015 Diego Nehab.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/tools/rply/rply.c
+++ b/tools/rply/rply.c
@@ -1,7 +1,7 @@
 /* ----------------------------------------------------------------------
  * RPly library, read/write PLY files
- * Diego Nehab, Princeton University
- * http://www.cs.princeton.edu/~diego/professional/rply
+ * Diego Nehab, IMPA
+ * http://www.impa.br/~diego/software/rply
  *
  * This library is distributed under the MIT License. See notice
  * at the end of this file.
@@ -17,16 +17,56 @@
 #include <stddef.h>
 
 #include "rply.h"
+#include "rplyfile.h"
 
 /* ----------------------------------------------------------------------
- * Constants 
+ * Make sure we get our integer types right
+ * ---------------------------------------------------------------------- */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+/* C99 stdint.h only supported in MSVC++ 10.0 and up */
+typedef __int8 t_ply_int8;
+typedef __int16 t_ply_int16;
+typedef __int32 t_ply_int32;
+typedef unsigned __int8 t_ply_uint8;
+typedef unsigned __int16 t_ply_uint16;
+typedef unsigned __int32 t_ply_uint32;
+#define PLY_INT8_MAX (127)
+#define PLY_INT8_MIN (-PLY_INT8_MAX-1)
+#define PLY_INT16_MAX (32767)
+#define PLY_INT16_MIN (-PLY_INT16_MAX-1)
+#define PLY_INT32_MAX (2147483647)
+#define PLY_INT32_MIN (-PLY_INT32_MAX-1)
+#define PLY_UINT8_MAX (255)
+#define PLY_UINT16_MAX (65535)
+#define PLY_UINT32_MAX  (4294967295)
+#else
+#include <stdint.h>
+typedef int8_t t_ply_int8;
+typedef int16_t t_ply_int16;
+typedef int32_t t_ply_int32;
+typedef uint8_t t_ply_uint8;
+typedef uint16_t t_ply_uint16;
+typedef uint32_t t_ply_uint32;
+#define PLY_INT8_MIN INT8_MIN
+#define PLY_INT8_MAX INT8_MAX
+#define PLY_INT16_MIN INT16_MIN
+#define PLY_INT16_MAX INT16_MAX
+#define PLY_INT32_MIN INT32_MIN
+#define PLY_INT32_MAX INT32_MAX
+#define PLY_UINT8_MAX UINT8_MAX
+#define PLY_UINT16_MAX UINT16_MAX
+#define PLY_UINT32_MAX UINT32_MAX
+#endif
+
+/* ----------------------------------------------------------------------
+ * Constants
  * ---------------------------------------------------------------------- */
 #define WORDSIZE 256
 #define LINESIZE 1024
 #define BUFFERSIZE (8*1024)
 
 typedef enum e_ply_io_mode_ {
-    PLY_READ, 
+    PLY_READ,
     PLY_WRITE
 } e_ply_io_mode;
 
@@ -35,9 +75,9 @@ static const char *const ply_storage_mode_list[] = {
 };     /* order matches e_ply_storage_mode enum */
 
 static const char *const ply_type_list[] = {
-    "int8", "uint8", "int16", "uint16", 
+    "int8", "uint8", "int16", "uint16",
     "int32", "uint32", "float32", "float64",
-    "char", "uchar", "short", "ushort", 
+    "char", "uchar", "short", "ushort",
     "int", "uint", "float", "double",
     "list", NULL
 };     /* order matches e_ply_type enum */
@@ -54,7 +94,7 @@ static const char *const ply_type_list[] = {
  * value: value of property
  * pdata/idata: user data defined with ply_set_cb
  *
- * Returns handle to ply file if succesful, NULL otherwise.
+ * Returns handle to PLY file if succesful, NULL otherwise.
  * ---------------------------------------------------------------------- */
 typedef struct t_ply_argument_ {
     p_ply_element element;
@@ -82,7 +122,7 @@ typedef struct t_ply_property_ {
     p_ply_read_cb read_cb;
     void *pdata;
     long idata;
-} t_ply_property; 
+} t_ply_property;
 
 /* ----------------------------------------------------------------------
  * Element information
@@ -104,8 +144,8 @@ typedef struct t_ply_element_ {
 /* ----------------------------------------------------------------------
  * Input/output driver
  *
- * Depending on file mode, different functions are used to read/write 
- * property fields. The drivers make it transparent to read/write in ascii, 
+ * Depending on file mode, different functions are used to read/write
+ * property fields. The drivers make it transparent to read/write in ascii,
  * big endian or little endian cases.
  * ---------------------------------------------------------------------- */
 typedef int (*p_ply_ihandler)(p_ply ply, double *value);
@@ -127,7 +167,7 @@ typedef struct t_ply_odriver_ {
 typedef t_ply_odriver *p_ply_odriver;
 
 /* ----------------------------------------------------------------------
- * Ply file handle. 
+ * Ply file handle.
  *
  * io_mode: read or write (from e_ply_io_mode)
  * storage_mode: mode of file associated with handle (from e_ply_storage_mode)
@@ -138,17 +178,18 @@ typedef t_ply_odriver *p_ply_odriver;
  * obj_info: obj_info items for this file
  * nobj_infos: number of obj_info items in file
  * fp: file pointer associated with ply file
- * c: last character read from ply file
+ * rn: skip extra char after end_header?
  * buffer: last word/chunck of data read from ply file
  * buffer_first, buffer_last: interval of untouched good data in buffer
  * buffer_token: start of parsed token (line or word) in buffer
- * idriver, odriver: input driver used to get property fields from file 
+ * idriver, odriver: input driver used to get property fields from file
  * argument: storage space for callback arguments
  * welement, wproperty: element/property type being written
  * winstance_index: index of instance of current element being written
- * wvalue_index: index of list property value being written 
+ * wvalue_index: index of list property value being written
  * wlength: number of values in list property being written
- * error_cb: callback for error messages
+ * error_cb: error callback
+ * pdata/idata: user data defined with ply_open/ply_create
  * ---------------------------------------------------------------------- */
 typedef struct t_ply_ {
     e_ply_io_mode io_mode;
@@ -160,7 +201,8 @@ typedef struct t_ply_ {
     char *obj_info;
     long nobj_infos;
     FILE *fp;
-    int c;
+    int own_fp;
+    int rn;
     char buffer[BUFFERSIZE];
     size_t buffer_first, buffer_token, buffer_last;
     p_ply_idriver idriver;
@@ -169,6 +211,8 @@ typedef struct t_ply_ {
     long welement, wproperty;
     long winstance_index, wvalue_index, wlength;
     p_ply_error_cb error_cb;
+    void *pdata;
+    long idata;
 } t_ply;
 
 /* ----------------------------------------------------------------------
@@ -183,6 +227,7 @@ static t_ply_odriver ply_odriver_binary_reverse;
 
 static int ply_read_word(p_ply ply);
 static int ply_check_word(p_ply ply);
+static void ply_finish_word(p_ply ply, size_t size);
 static int ply_read_line(p_ply ply);
 static int ply_check_line(p_ply ply);
 static int ply_read_chunk(p_ply ply, void *anybuffer, size_t size);
@@ -196,12 +241,13 @@ static void ply_reverse(void *anydata, size_t size);
  * ---------------------------------------------------------------------- */
 static int ply_find_string(const char *item, const char* const list[]);
 static p_ply_element ply_find_element(p_ply ply, const char *name);
-static p_ply_property ply_find_property(p_ply_element element, 
+static p_ply_property ply_find_property(p_ply_element element,
         const char *name);
 
 /* ----------------------------------------------------------------------
  * Header parsing
  * ---------------------------------------------------------------------- */
+static int ply_read_header_magic(p_ply ply);
 static int ply_read_header_format(p_ply ply);
 static int ply_read_header_comment(p_ply ply);
 static int ply_read_header_obj_info(p_ply ply);
@@ -211,8 +257,8 @@ static int ply_read_header_element(p_ply ply);
 /* ----------------------------------------------------------------------
  * Error handling
  * ---------------------------------------------------------------------- */
-static void ply_error_cb(const char *message);
-static void ply_error(p_ply ply, const char *fmt, ...);
+static void ply_error_cb(p_ply ply, const char *message);
+static void ply_ferror(p_ply ply, const char *fmt, ...);
 
 /* ----------------------------------------------------------------------
  * Memory allocation and initialization
@@ -229,20 +275,19 @@ static void *ply_grow_array(p_ply ply, void **pointer, long *nmemb, long size);
  * Special functions
  * ---------------------------------------------------------------------- */
 static e_ply_storage_mode ply_arch_endian(void);
-static int ply_type_check(void); 
+static int ply_type_check(void);
 
 /* ----------------------------------------------------------------------
  * Auxiliary read functions
  * ---------------------------------------------------------------------- */
-static int ply_read_element(p_ply ply, p_ply_element element, 
+static int ply_read_element(p_ply ply, p_ply_element element,
         p_ply_argument argument);
-static int ply_read_property(p_ply ply, p_ply_element element, 
+static int ply_read_property(p_ply ply, p_ply_element element,
         p_ply_property property, p_ply_argument argument);
-static int ply_read_list_property(p_ply ply, p_ply_element element, 
+static int ply_read_list_property(p_ply ply, p_ply_element element,
         p_ply_property property, p_ply_argument argument);
-static int ply_read_scalar_property(p_ply ply, p_ply_element element, 
+static int ply_read_scalar_property(p_ply ply, p_ply_element element,
         p_ply_property property, p_ply_argument argument);
-
 
 /* ----------------------------------------------------------------------
  * Buffer support functions
@@ -252,10 +297,10 @@ static int ply_read_scalar_property(p_ply ply, p_ply_element element,
 #define BLINE(p) (p->buffer + p->buffer_token)
 
 /* pointer to start of untouched bytes in buffer */
-#define BFIRST(p) (p->buffer + p->buffer_first) 
+#define BFIRST(p) (p->buffer + p->buffer_first)
 
 /* number of bytes untouched in buffer */
-#define BSIZE(p) (p->buffer_last - p->buffer_first) 
+#define BSIZE(p) (p->buffer_last - p->buffer_first)
 
 /* consumes data from buffer */
 #define BSKIP(p, s) (p->buffer_first += s)
@@ -269,12 +314,36 @@ static int BREFILL(p_ply ply) {
     ply->buffer_first = ply->buffer_token = 0;
     /* fill remaining with new data */
     size = fread(ply->buffer+size, 1, BUFFERSIZE-size-1, ply->fp);
-    /* place sentinel so we can use str* functions with buffer */
-    ply->buffer[BUFFERSIZE-1] = '\0';
-    /* check if read failed */
-    if (size <= 0) return 0;
     /* increase size to account for new data */
     ply->buffer_last += size;
+    /* place sentinel so we can use str* functions with buffer */
+    ply->buffer[ply->buffer_last] = '\0';
+    /* check if read failed */
+    return size > 0;
+}
+
+/* We don't care about end-of-line, generally, because we
+ * separate words by any white-space character.
+ * Unfortunately, in binary mode, right after 'end_header',
+ * we have to know *exactly* how many characters to skip */
+/* We use the end-of-line marker after the 'ply' magic
+ * number to figure out what to do */
+static int ply_read_header_magic(p_ply ply) {
+    char *magic = ply->buffer;
+    if (!BREFILL(ply)) {
+        ply->error_cb(ply, "Unable to read magic number from file");
+        return 0;
+    }
+    /* check if it is ply */
+    if (magic[0] != 'p' || magic[1] != 'l' || magic[2] != 'y'
+            || !isspace(magic[3])) {
+        ply->error_cb(ply, "Wrong magic number. Expected 'ply'");
+        return 0;
+    }
+    /* figure out if we have to skip the extra character
+     * after header when we reach the binary part of file */
+    ply->rn = magic[3] == '\r' && magic[4] == '\n';
+    BSKIP(ply, 3);
     return 1;
 }
 
@@ -284,67 +353,79 @@ static int BREFILL(p_ply ply) {
 /* ----------------------------------------------------------------------
  * Read support functions
  * ---------------------------------------------------------------------- */
-p_ply ply_open(const char *name, p_ply_error_cb error_cb) {
-    char magic[5] = "    ";
-    FILE *fp = NULL; 
-    p_ply ply = NULL;
+p_ply ply_open(const char *name, p_ply_error_cb error_cb,
+        long idata, void *pdata) {
+    FILE *fp;
+    p_ply ply;
     if (error_cb == NULL) error_cb = ply_error_cb;
-    if (!ply_type_check()) {
-        error_cb("Incompatible type system");
-        return NULL;
-    }
     assert(name);
     fp = fopen(name, "rb");
     if (!fp) {
-        error_cb("Unable to open file");
+        error_cb(NULL, "Unable to open file");
         return NULL;
     }
-    if (fread(magic, 1, 4, fp) < 4) {
-        error_cb("Error reading from file");
-        fclose(fp);
-        return NULL;
-    }
-    if (strcmp(magic, "ply\n")) {
-        fclose(fp);
-        error_cb("Not a PLY file. Expected magic number 'ply\\n'");
+    ply = ply_open_from_file(fp, error_cb, idata, pdata);
+    if (ply) ply->own_fp = 1;
+    else fclose(fp);
+    return ply;
+}
+
+p_ply ply_open_from_file(FILE *fp, p_ply_error_cb error_cb,
+        long idata, void *pdata) {
+    p_ply ply;
+    if (error_cb == NULL) error_cb = ply_error_cb;
+    assert(fp);
+    if (!ply_type_check()) {
+        error_cb(ply, "Incompatible type system");
         return NULL;
     }
     ply = ply_alloc();
     if (!ply) {
-        error_cb("Out of memory");
-        fclose(fp);
+        error_cb(NULL, "Out of memory");
         return NULL;
     }
-    ply->fp = fp;
+    ply->idata = idata;
+    ply->pdata = pdata;
     ply->io_mode = PLY_READ;
     ply->error_cb = error_cb;
+    ply->fp = fp;
+    ply->own_fp = 0;
     return ply;
 }
 
 int ply_read_header(p_ply ply) {
     assert(ply && ply->fp && ply->io_mode == PLY_READ);
+    if (!ply_read_header_magic(ply)) return 0;
     if (!ply_read_word(ply)) return 0;
     /* parse file format */
     if (!ply_read_header_format(ply)) {
-        ply_error(ply, "Invalid file format");
+        ply_ferror(ply, "Invalid file format");
         return 0;
     }
     /* parse elements, comments or obj_infos until the end of header */
     while (strcmp(BWORD(ply), "end_header")) {
-        if (!ply_read_header_comment(ply) && 
-                !ply_read_header_element(ply) && 
+        if (!ply_read_header_comment(ply) &&
+                !ply_read_header_element(ply) &&
                 !ply_read_header_obj_info(ply)) {
-            ply_error(ply, "Unexpected token '%s'", BWORD(ply));
+            ply_ferror(ply, "Unexpected token '%s'", BWORD(ply));
             return 0;
         }
+    }
+    /* skip extra character? */
+    if (ply->rn) {
+        if (BSIZE(ply) < 1 && !BREFILL(ply)) {
+            ply_ferror(ply, "Unexpected end of file");
+            return 0;
+        }
+        BSKIP(ply, 1);
     }
     return 1;
 }
 
-long ply_set_read_cb(p_ply ply, const char *element_name, 
-        const char* property_name, p_ply_read_cb read_cb, 
+long ply_set_read_cb(p_ply ply, const char *element_name,
+        const char* property_name, p_ply_read_cb read_cb,
         void *pdata, long idata) {
-    p_ply_element element = NULL; 
+    p_ply_element element = NULL;
     p_ply_property property = NULL;
     assert(ply && element_name && property_name);
     element = ply_find_element(ply, element_name);
@@ -375,45 +456,58 @@ int ply_read(p_ply ply) {
 /* ----------------------------------------------------------------------
  * Write support functions
  * ---------------------------------------------------------------------- */
-p_ply ply_create(const char *name, e_ply_storage_mode storage_mode, 
-        p_ply_error_cb error_cb) {
-    FILE *fp = NULL;
+p_ply ply_create(const char *name, e_ply_storage_mode storage_mode,
+        p_ply_error_cb error_cb, long idata, void *pdata) {
     p_ply ply = NULL;
-    if (error_cb == NULL) error_cb = ply_error_cb;
-    if (!ply_type_check()) {
-        error_cb("Incompatible type system");
-        return NULL;
-    }
+    FILE *fp = NULL;
     assert(name && storage_mode <= PLY_DEFAULT);
+    if (error_cb == NULL) error_cb = ply_error_cb;
     fp = fopen(name, "wb");
     if (!fp) {
-        error_cb("Unable to create file");
+        error_cb(ply, "Unable to create file");
+        return NULL;
+    }
+    ply = ply_create_to_file(fp, storage_mode, error_cb, idata, pdata);
+    if (ply) ply->own_fp = 1;
+    else fclose(fp);
+    return ply;
+}
+
+p_ply ply_create_to_file(FILE *fp, e_ply_storage_mode storage_mode,
+        p_ply_error_cb error_cb, long idata, void *pdata) {
+    p_ply ply;
+    assert(fp && storage_mode <= PLY_DEFAULT);
+    if (!ply_type_check()) {
+        error_cb(ply, "Incompatible type system");
         return NULL;
     }
     ply = ply_alloc();
     if (!ply) {
-        fclose(fp);
-        error_cb("Out of memory");
+        error_cb(NULL, "Out of memory");
         return NULL;
     }
+    ply->idata = idata;
+    ply->pdata = pdata;
     ply->io_mode = PLY_WRITE;
     if (storage_mode == PLY_DEFAULT) storage_mode = ply_arch_endian();
     if (storage_mode == PLY_ASCII) ply->odriver = &ply_odriver_ascii;
-    else if (storage_mode == ply_arch_endian()) 
+    else if (storage_mode == ply_arch_endian())
         ply->odriver = &ply_odriver_binary;
     else ply->odriver = &ply_odriver_binary_reverse;
     ply->storage_mode = storage_mode;
     ply->fp = fp;
+    ply->own_fp = 0;
     ply->error_cb = error_cb;
     return ply;
 }
+
 
 int ply_add_element(p_ply ply, const char *name, long ninstances) {
     p_ply_element element = NULL;
     assert(ply && ply->fp && ply->io_mode == PLY_WRITE);
     assert(name && strlen(name) < WORDSIZE && ninstances >= 0);
     if (strlen(name) >= WORDSIZE || ninstances < 0) {
-        ply_error(ply, "Invalid arguments");
+        ply_ferror(ply, "Invalid arguments");
         return 0;
     }
     element = ply_grow_element(ply);
@@ -430,7 +524,7 @@ int ply_add_scalar_property(p_ply ply, const char *name, e_ply_type type) {
     assert(name && strlen(name) < WORDSIZE);
     assert(type < PLY_LIST);
     if (strlen(name) >= WORDSIZE || type >= PLY_LIST) {
-        ply_error(ply, "Invalid arguments");
+        ply_ferror(ply, "Invalid arguments");
         return 0;
     }
     element = &ply->element[ply->nelements-1];
@@ -441,20 +535,20 @@ int ply_add_scalar_property(p_ply ply, const char *name, e_ply_type type) {
     return 1;
 }
 
-int ply_add_list_property(p_ply ply, const char *name, 
+int ply_add_list_property(p_ply ply, const char *name,
         e_ply_type length_type, e_ply_type value_type) {
     p_ply_element element = NULL;
     p_ply_property property = NULL;
     assert(ply && ply->fp && ply->io_mode == PLY_WRITE);
     assert(name && strlen(name) < WORDSIZE);
     if (strlen(name) >= WORDSIZE) {
-        ply_error(ply, "Invalid arguments");
+        ply_ferror(ply, "Invalid arguments");
         return 0;
     }
     assert(length_type < PLY_LIST);
     assert(value_type < PLY_LIST);
     if (length_type >= PLY_LIST || value_type >= PLY_LIST) {
-        ply_error(ply, "Invalid arguments");
+        ply_ferror(ply, "Invalid arguments");
         return 0;
     }
     element = &ply->element[ply->nelements-1];
@@ -469,9 +563,9 @@ int ply_add_list_property(p_ply ply, const char *name,
 
 int ply_add_property(p_ply ply, const char *name, e_ply_type type,
         e_ply_type length_type, e_ply_type value_type) {
-    if (type == PLY_LIST) 
+    if (type == PLY_LIST)
         return ply_add_list_property(ply, name, length_type, value_type);
-    else 
+    else
         return ply_add_scalar_property(ply, name, type);
 }
 
@@ -479,7 +573,7 @@ int ply_add_comment(p_ply ply, const char *comment) {
     char *new_comment = NULL;
     assert(ply && comment && strlen(comment) < LINESIZE);
     if (!comment || strlen(comment) >= LINESIZE) {
-        ply_error(ply, "Invalid arguments");
+        ply_ferror(ply, "Invalid arguments");
         return 0;
     }
     new_comment = (char *) ply_grow_array(ply, (void **) &ply->comment,
@@ -493,7 +587,7 @@ int ply_add_obj_info(p_ply ply, const char *obj_info) {
     char *new_obj_info = NULL;
     assert(ply && obj_info && strlen(obj_info) < LINESIZE);
     if (!obj_info || strlen(obj_info) >= LINESIZE) {
-        ply_error(ply, "Invalid arguments");
+        ply_ferror(ply, "Invalid arguments");
         return 0;
     }
     new_obj_info = (char *) ply_grow_array(ply, (void **) &ply->obj_info,
@@ -506,9 +600,9 @@ int ply_add_obj_info(p_ply ply, const char *obj_info) {
 int ply_write_header(p_ply ply) {
     long i, j;
     assert(ply && ply->fp && ply->io_mode == PLY_WRITE);
-    assert(ply->element || ply->nelements == 0); 
-    assert(!ply->element || ply->nelements > 0); 
-    if (fprintf(ply->fp, "ply\nformat %s 1.0\n", 
+    assert(ply->element || ply->nelements == 0);
+    assert(!ply->element || ply->nelements > 0);
+    if (fprintf(ply->fp, "ply\nformat %s 1.0\n",
                 ply_storage_mode_list[ply->storage_mode]) <= 0) goto error;
     for (i = 0; i < ply->ncomments; i++)
         if (fprintf(ply->fp, "comment %s\n", ply->comment + LINESIZE*i) <= 0)
@@ -518,19 +612,19 @@ int ply_write_header(p_ply ply) {
             goto error;
     for (i = 0; i < ply->nelements; i++) {
         p_ply_element element = &ply->element[i];
-        assert(element->property || element->nproperties == 0); 
-        assert(!element->property || element->nproperties > 0); 
-        if (fprintf(ply->fp, "element %s %ld\n", element->name, 
+        assert(element->property || element->nproperties == 0);
+        assert(!element->property || element->nproperties > 0);
+        if (fprintf(ply->fp, "element %s %ld\n", element->name,
                     element->ninstances) <= 0) goto error;
         for (j = 0; j < element->nproperties; j++) {
             p_ply_property property = &element->property[j];
             if (property->type == PLY_LIST) {
-                if (fprintf(ply->fp, "property list %s %s %s\n", 
+                if (fprintf(ply->fp, "property list %s %s %s\n",
                             ply_type_list[property->length_type],
                             ply_type_list[property->value_type],
                             property->name) <= 0) goto error;
             } else {
-                if (fprintf(ply->fp, "property %s %s\n", 
+                if (fprintf(ply->fp, "property %s %s\n",
                             ply_type_list[property->type],
                             property->name) <= 0) goto error;
             }
@@ -538,7 +632,7 @@ int ply_write_header(p_ply ply) {
     }
     return fprintf(ply->fp, "end_header\n") > 0;
 error:
-    ply_error(ply, "Error writing to file");
+    ply_ferror(ply, "Error writing to file");
     return 0;
 }
 
@@ -547,6 +641,7 @@ int ply_write(p_ply ply, double value) {
     p_ply_property property = NULL;
     int type = -1;
     int breakafter = 0;
+    int spaceafter = 1;
     if (ply->welement > ply->nelements) return 0;
     element = &ply->element[ply->welement];
     if (ply->wproperty > element->nproperties) return 0;
@@ -561,9 +656,9 @@ int ply_write(p_ply ply, double value) {
         ply->wlength = 0;
     }
     if (!ply->odriver->ohandler[type](ply, value)) {
-        ply_error(ply, "Failed writing %s of %s %d (%s: %s)", 
-                    property->name, element->name, 
-                    ply->winstance_index, 
+        ply_ferror(ply, "Failed writing %s of %s %d (%s: %s)",
+                    property->name, element->name,
+                    ply->winstance_index,
                     ply->odriver->name, ply_type_list[type]);
         return 0;
     }
@@ -575,13 +670,22 @@ int ply_write(p_ply ply, double value) {
     if (ply->wproperty >= element->nproperties) {
         ply->wproperty = 0;
         ply->winstance_index++;
-        if (ply->storage_mode == PLY_ASCII) breakafter = 1;
+        breakafter = 1;
+        spaceafter = 0;
     }
     if (ply->winstance_index >= element->ninstances) {
         ply->winstance_index = 0;
-        ply->welement++;
+        do {
+            ply->welement++;
+            element = &ply->element[ply->welement];
+        } while (ply->welement < ply->nelements && !element->ninstances);
     }
-    return !breakafter || putc('\n', ply->fp) > 0;
+    if (ply->storage_mode == PLY_ASCII) {
+        return (!spaceafter || putc(' ', ply->fp) > 0) &&
+               (!breakafter || putc('\n', ply->fp) > 0);
+    } else {
+        return 1;
+    }
 }
 
 int ply_close(p_ply ply) {
@@ -590,12 +694,12 @@ int ply_close(p_ply ply) {
     assert(ply->element || ply->nelements == 0);
     assert(!ply->element || ply->nelements > 0);
     /* write last chunk to file */
-    if (ply->io_mode == PLY_WRITE && 
+    if (ply->io_mode == PLY_WRITE &&
       fwrite(ply->buffer, 1, ply->buffer_last, ply->fp) < ply->buffer_last) {
-        ply_error(ply, "Error closing up");
+        ply_ferror(ply, "Error closing up");
         return 0;
     }
-    fclose(ply->fp);
+    if (ply->own_fp) fclose(ply->fp);
     /* free all memory used by handle */
     if (ply->element) {
         for (i = 0; i < ply->nelements; i++) {
@@ -613,7 +717,7 @@ int ply_close(p_ply ply) {
 /* ----------------------------------------------------------------------
  * Query support functions
  * ---------------------------------------------------------------------- */
-p_ply_element ply_get_next_element(p_ply ply, 
+p_ply_element ply_get_next_element(p_ply ply,
         p_ply_element last) {
     assert(ply);
     if (!last) return ply->element;
@@ -630,7 +734,7 @@ int ply_get_element_info(p_ply_element element, const char** name,
     return 1;
 }
 
-p_ply_property ply_get_next_property(p_ply_element element, 
+p_ply_property ply_get_next_property(p_ply_element element,
         p_ply_property last) {
     assert(element);
     if (!last) return element->property;
@@ -652,7 +756,7 @@ int ply_get_property_info(p_ply_property property, const char** name,
 
 const char *ply_get_next_comment(p_ply ply, const char *last) {
     assert(ply);
-    if (!last) return ply->comment; 
+    if (!last) return ply->comment;
     last += LINESIZE;
     if (last < ply->comment + LINESIZE*ply->ncomments) return last;
     else return NULL;
@@ -660,16 +764,16 @@ const char *ply_get_next_comment(p_ply ply, const char *last) {
 
 const char *ply_get_next_obj_info(p_ply ply, const char *last) {
     assert(ply);
-    if (!last) return ply->obj_info; 
+    if (!last) return ply->obj_info;
     last += LINESIZE;
     if (last < ply->obj_info + LINESIZE*ply->nobj_infos) return last;
     else return NULL;
 }
 
 /* ----------------------------------------------------------------------
- * Callback argument support functions 
+ * Callback argument support functions
  * ---------------------------------------------------------------------- */
-int ply_get_argument_element(p_ply_argument argument, 
+int ply_get_argument_element(p_ply_argument argument,
         p_ply_element *element, long *instance_index) {
     assert(argument);
     if (!argument) return 0;
@@ -678,7 +782,7 @@ int ply_get_argument_element(p_ply_argument argument,
     return 1;
 }
 
-int ply_get_argument_property(p_ply_argument argument, 
+int ply_get_argument_property(p_ply_argument argument,
         p_ply_property *property, long *length, long *value_index) {
     assert(argument);
     if (!argument) return 0;
@@ -688,7 +792,7 @@ int ply_get_argument_property(p_ply_argument argument,
     return 1;
 }
 
-int ply_get_argument_user_data(p_ply_argument argument, void **pdata, 
+int ply_get_argument_user_data(p_ply_argument argument, void **pdata,
         long *idata) {
     assert(argument);
     if (!argument) return 0;
@@ -703,19 +807,27 @@ double ply_get_argument_value(p_ply_argument argument) {
     return argument->value;
 }
 
+int ply_get_ply_user_data(p_ply ply, void **pdata, long *idata) {
+    assert(ply);
+    if (!ply) return 0;
+    if (pdata) *pdata = ply->pdata;
+    if (idata) *idata = ply->idata;
+    return 1;
+}
+
 /* ----------------------------------------------------------------------
  * Internal functions
  * ---------------------------------------------------------------------- */
-static int ply_read_list_property(p_ply ply, p_ply_element element, 
+static int ply_read_list_property(p_ply ply, p_ply_element element,
         p_ply_property property, p_ply_argument argument) {
     int l;
     p_ply_read_cb read_cb = property->read_cb;
-    p_ply_ihandler *driver = ply->idriver->ihandler; 
+    p_ply_ihandler *driver = ply->idriver->ihandler;
     /* get list length */
     p_ply_ihandler handler = driver[property->length_type];
     double length;
     if (!handler(ply, &length)) {
-        ply_error(ply, "Error reading '%s' of '%s' number %d",
+        ply_ferror(ply, "Error reading '%s' of '%s' number %d",
                 property->name, element->name, argument->instance_index);
         return 0;
     }
@@ -724,7 +836,7 @@ static int ply_read_list_property(p_ply ply, p_ply_element element,
     argument->value_index = -1;
     argument->value = length;
     if (read_cb && !read_cb(argument)) {
-        ply_error(ply, "Aborted by user");
+        ply_ferror(ply, "Aborted by user");
         return 0;
     }
     /* read list values */
@@ -734,48 +846,48 @@ static int ply_read_list_property(p_ply ply, p_ply_element element,
         /* read value from file */
         argument->value_index = l;
         if (!handler(ply, &argument->value)) {
-            ply_error(ply, "Error reading value number %d of '%s' of "
-                    "'%s' number %d", l+1, property->name, 
+            ply_ferror(ply, "Error reading value number %d of '%s' of "
+                    "'%s' number %d", l+1, property->name,
                     element->name, argument->instance_index);
             return 0;
         }
         /* invoke callback to pass value */
         if (read_cb && !read_cb(argument)) {
-            ply_error(ply, "Aborted by user");
+            ply_ferror(ply, "Aborted by user");
             return 0;
         }
     }
     return 1;
 }
 
-static int ply_read_scalar_property(p_ply ply, p_ply_element element, 
+static int ply_read_scalar_property(p_ply ply, p_ply_element element,
         p_ply_property property, p_ply_argument argument) {
     p_ply_read_cb read_cb = property->read_cb;
-    p_ply_ihandler *driver = ply->idriver->ihandler; 
+    p_ply_ihandler *driver = ply->idriver->ihandler;
     p_ply_ihandler handler = driver[property->type];
     argument->length = 1;
     argument->value_index = 0;
     if (!handler(ply, &argument->value)) {
-        ply_error(ply, "Error reading '%s' of '%s' number %d",
+        ply_ferror(ply, "Error reading '%s' of '%s' number %d",
                 property->name, element->name, argument->instance_index);
         return 0;
     }
     if (read_cb && !read_cb(argument)) {
-        ply_error(ply, "Aborted by user");
+        ply_ferror(ply, "Aborted by user");
         return 0;
     }
     return 1;
 }
 
-static int ply_read_property(p_ply ply, p_ply_element element, 
+static int ply_read_property(p_ply ply, p_ply_element element,
         p_ply_property property, p_ply_argument argument) {
-    if (property->type == PLY_LIST) 
+    if (property->type == PLY_LIST)
         return ply_read_list_property(ply, element, property, argument);
-    else 
+    else
         return ply_read_scalar_property(ply, element, property, argument);
 }
 
-static int ply_read_element(p_ply ply, p_ply_element element, 
+static int ply_read_element(p_ply ply, p_ply_element element,
         p_ply_argument argument) {
     long j, k;
     /* for each element of this type */
@@ -797,7 +909,7 @@ static int ply_read_element(p_ply ply, p_ply_element element,
 static int ply_find_string(const char *item, const char* const list[]) {
     int i;
     assert(item && list);
-    for (i = 0; list[i]; i++) 
+    for (i = 0; list[i]; i++)
         if (!strcmp(list[i], item)) return i;
     return -1;
 }
@@ -805,33 +917,37 @@ static int ply_find_string(const char *item, const char* const list[]) {
 static p_ply_element ply_find_element(p_ply ply, const char *name) {
     p_ply_element element;
     int i, nelements;
-    assert(ply && name); 
+    assert(ply && name);
     element = ply->element;
     nelements = ply->nelements;
-    assert(element || nelements == 0); 
-    assert(!element || nelements > 0); 
-    for (i = 0; i < nelements; i++) 
+    assert(element || nelements == 0);
+    assert(!element || nelements > 0);
+    for (i = 0; i < nelements; i++)
         if (!strcmp(element[i].name, name)) return &element[i];
     return NULL;
 }
 
-static p_ply_property ply_find_property(p_ply_element element, 
+static p_ply_property ply_find_property(p_ply_element element,
         const char *name) {
     p_ply_property property;
     int i, nproperties;
-    assert(element && name); 
+    assert(element && name);
     property = element->property;
     nproperties = element->nproperties;
-    assert(property || nproperties == 0); 
-    assert(!property || nproperties > 0); 
-    for (i = 0; i < nproperties; i++) 
+    assert(property || nproperties == 0);
+    assert(!property || nproperties > 0);
+    for (i = 0; i < nproperties; i++)
         if (!strcmp(property[i].name, name)) return &property[i];
     return NULL;
 }
 
 static int ply_check_word(p_ply ply) {
-    if (strlen(BLINE(ply)) >= WORDSIZE) {
-        ply_error(ply, "Word too long");
+    size_t size = strlen(BWORD(ply));
+    if (size >= WORDSIZE) {
+        ply_ferror(ply, "Word too long");
+        return 0;
+    } else if (size == 0) {
+        ply_ferror(ply, "Unexpected end of file");
         return 0;
     }
     return 1;
@@ -846,45 +962,49 @@ static int ply_read_word(p_ply ply) {
         /* check if all buffer was made of blanks */
         if (t >= BSIZE(ply)) {
             if (!BREFILL(ply)) {
-                ply_error(ply, "Unexpected end of file");
+                ply_ferror(ply, "Unexpected end of file");
                 return 0;
             }
-        } else break; 
-    } 
-    BSKIP(ply, t); 
+        } else break;
+    }
+    BSKIP(ply, t);
     /* look for a space after the current word */
     t = strcspn(BFIRST(ply), " \n\r\t");
     /* if we didn't reach the end of the buffer, we are done */
     if (t < BSIZE(ply)) {
-        ply->buffer_token = ply->buffer_first;
-        BSKIP(ply, t);
-        *BFIRST(ply) = '\0';
-        BSKIP(ply, 1);
+        ply_finish_word(ply, t);
         return ply_check_word(ply);
     }
     /* otherwise, try to refill buffer */
     if (!BREFILL(ply)) {
-        ply_error(ply, "Unexpected end of file");
-        return 0;
+        /* if we reached the end of file, try to do with what we have */
+        ply_finish_word(ply, t);
+        return ply_check_word(ply);
+        /* ply_ferror(ply, "Unexpected end of file"); */
+        /* return 0; */
     }
     /* keep looking from where we left */
     t += strcspn(BFIRST(ply) + t, " \n\r\t");
     /* check if the token is too large for our buffer */
     if (t >= BSIZE(ply)) {
-        ply_error(ply, "Token too large");
+        ply_ferror(ply, "Token too large");
         return 0;
     }
     /* we are done */
+    ply_finish_word(ply, t);
+    return ply_check_word(ply);
+}
+
+static void ply_finish_word(p_ply ply, size_t size) {
     ply->buffer_token = ply->buffer_first;
-    BSKIP(ply, t);
+    BSKIP(ply, size);
     *BFIRST(ply) = '\0';
     BSKIP(ply, 1);
-    return ply_check_word(ply);
 }
 
 static int ply_check_line(p_ply ply) {
     if (strlen(BLINE(ply)) >= LINESIZE) {
-        ply_error(ply, "Line too long");
+        ply_ferror(ply, "Line too long");
         return 0;
     }
     return 1;
@@ -903,10 +1023,10 @@ static int ply_read_line(p_ply ply) {
         BSKIP(ply, 1);
         return ply_check_line(ply);
     } else {
-        end = ply->buffer + BSIZE(ply); 
+        end = ply->buffer + BSIZE(ply);
         /* otherwise, try to refill buffer */
         if (!BREFILL(ply)) {
-            ply_error(ply, "Unexpected end of file");
+            ply_ferror(ply, "Unexpected end of file");
             return 0;
         }
     }
@@ -914,7 +1034,7 @@ static int ply_read_line(p_ply ply) {
     end = strchr(end, '\n');
     /* check if the token is too large for our buffer */
     if (!end) {
-        ply_error(ply, "Token too large");
+        ply_ferror(ply, "Token too large");
         return 0;
     }
     /* we are done */
@@ -989,7 +1109,6 @@ static void ply_reverse(void *anydata, size_t size) {
 }
 
 static void ply_init(p_ply ply) {
-    ply->c = ' ';
     ply->element = NULL;
     ply->nelements = 0;
     ply->comment = NULL;
@@ -1011,7 +1130,7 @@ static void ply_element_init(p_ply_element element) {
     element->name[0] = '\0';
     element->ninstances = 0;
     element->property = NULL;
-    element->nproperties = 0; 
+    element->nproperties = 0;
 }
 
 static void ply_property_init(p_ply_property property) {
@@ -1025,20 +1144,20 @@ static void ply_property_init(p_ply_property property) {
 }
 
 static p_ply ply_alloc(void) {
-    p_ply ply = (p_ply) malloc(sizeof(t_ply));
+    p_ply ply = (p_ply) calloc(1, sizeof(t_ply));
     if (!ply) return NULL;
     ply_init(ply);
     return ply;
 }
 
-static void *ply_grow_array(p_ply ply, void **pointer, 
+static void *ply_grow_array(p_ply ply, void **pointer,
         long *nmemb, long size) {
     void *temp = *pointer;
     long count = *nmemb + 1;
     if (!temp) temp = malloc(count*size);
     else temp = realloc(temp, count*size);
     if (!temp) {
-        ply_error(ply, "Out of memory");
+        ply_ferror(ply, "Out of memory");
         return NULL;
     }
     *pointer = temp;
@@ -1048,14 +1167,14 @@ static void *ply_grow_array(p_ply ply, void **pointer,
 
 static p_ply_element ply_grow_element(p_ply ply) {
     p_ply_element element = NULL;
-    assert(ply); 
-    assert(ply->element || ply->nelements == 0); 
-    assert(!ply->element || ply->nelements > 0); 
-    element = (p_ply_element) ply_grow_array(ply, (void **) &ply->element, 
+    assert(ply);
+    assert(ply->element || ply->nelements == 0);
+    assert(!ply->element || ply->nelements > 0);
+    element = (p_ply_element) ply_grow_array(ply, (void **) &ply->element,
             &ply->nelements, sizeof(t_ply_element));
     if (!element) return NULL;
     ply_element_init(element);
-    return element; 
+    return element;
 }
 
 static p_ply_property ply_grow_property(p_ply ply, p_ply_element element) {
@@ -1064,8 +1183,8 @@ static p_ply_property ply_grow_property(p_ply ply, p_ply_element element) {
     assert(element);
     assert(element->property || element->nproperties == 0);
     assert(!element->property || element->nproperties > 0);
-    property = (p_ply_property) ply_grow_array(ply, 
-            (void **) &element->property, 
+    property = (p_ply_property) ply_grow_array(ply,
+            (void **) &element->property,
             &element->nproperties, sizeof(t_ply_property));
     if (!property) return NULL;
     ply_property_init(property);
@@ -1079,7 +1198,7 @@ static int ply_read_header_format(p_ply ply) {
     ply->storage_mode = ply_find_string(BWORD(ply), ply_storage_mode_list);
     if (ply->storage_mode == (e_ply_storage_mode) (-1)) return 0;
     if (ply->storage_mode == PLY_ASCII) ply->idriver = &ply_idriver_ascii;
-    else if (ply->storage_mode == ply_arch_endian()) 
+    else if (ply->storage_mode == ply_arch_endian())
         ply->idriver = &ply_idriver_binary;
     else ply->idriver = &ply_idriver_binary_reverse;
     if (!ply_read_word(ply)) return 0;
@@ -1148,29 +1267,30 @@ static int ply_read_header_element(p_ply ply) {
     /* get number of elements of this type */
     if (!ply_read_word(ply)) return 0;
     if (sscanf(BWORD(ply), "%ld", &dummy) != 1) {
-        ply_error(ply, "Expected number got '%s'", BWORD(ply));
+        ply_ferror(ply, "Expected number got '%s'", BWORD(ply));
         return 0;
     }
     element->ninstances = dummy;
     /* get all properties for this element */
     if (!ply_read_word(ply)) return 0;
-    while (ply_read_header_property(ply) || 
+    while (ply_read_header_property(ply) ||
         ply_read_header_comment(ply) || ply_read_header_obj_info(ply))
         /* do nothing */;
     return 1;
 }
 
-static void ply_error_cb(const char *message) {
+static void ply_error_cb(p_ply ply, const char *message) {
+    (void) ply;
     fprintf(stderr, "RPly: %s\n", message);
 }
 
-static void ply_error(p_ply ply, const char *fmt, ...) {
+static void ply_ferror(p_ply ply, const char *fmt, ...) {
     char buffer[1024];
     va_list ap;
     va_start(ap, fmt);
     vsprintf(buffer, fmt, ap);
     va_end(ap);
-    ply->error_cb(buffer);
+    ply->error_cb(ply, buffer);
 }
 
 static e_ply_storage_mode ply_arch_endian(void) {
@@ -1181,20 +1301,20 @@ static e_ply_storage_mode ply_arch_endian(void) {
 }
 
 static int ply_type_check(void) {
-    assert(sizeof(char) == 1);
-    assert(sizeof(unsigned char) == 1);
-    assert(sizeof(short) == 2);
-    assert(sizeof(unsigned short) == 2);
-    assert(sizeof(int) == 4);
-    assert(sizeof(unsigned int) == 4);
+    assert(sizeof(t_ply_int8) == 1);
+    assert(sizeof(t_ply_uint8) == 1);
+    assert(sizeof(t_ply_int16) == 2);
+    assert(sizeof(t_ply_uint16) == 2);
+    assert(sizeof(t_ply_int32) == 4);
+    assert(sizeof(t_ply_uint32) == 4);
     assert(sizeof(float) == 4);
     assert(sizeof(double) == 8);
-    if (sizeof(char) != 1) return 0;
-    if (sizeof(unsigned char) != 1) return 0;
-    if (sizeof(short) != 2) return 0;
-    if (sizeof(unsigned short) != 2) return 0;
-    if (sizeof(int) != 4) return 0;
-    if (sizeof(unsigned int) != 4) return 0;
+    if (sizeof(t_ply_int8) != 1) return 0;
+    if (sizeof(t_ply_uint8) != 1) return 0;
+    if (sizeof(t_ply_int16) != 2) return 0;
+    if (sizeof(t_ply_uint16) != 2) return 0;
+    if (sizeof(t_ply_int32) != 4) return 0;
+    if (sizeof(t_ply_uint32) != 4) return 0;
     if (sizeof(float) != 4) return 0;
     if (sizeof(double) != 8) return 0;
     return 1;
@@ -1204,78 +1324,78 @@ static int ply_type_check(void) {
  * Output handlers
  * ---------------------------------------------------------------------- */
 static int oascii_int8(p_ply ply, double value) {
-    if (value > CHAR_MAX || value < CHAR_MIN) return 0;
-    return fprintf(ply->fp, "%d ", (char) value) > 0;
+    if (value > PLY_INT8_MAX || value < PLY_INT8_MIN) return 0;
+    return fprintf(ply->fp, "%d", (t_ply_int8) value) > 0;
 }
 
 static int oascii_uint8(p_ply ply, double value) {
-    if (value > UCHAR_MAX || value < 0) return 0;
-    return fprintf(ply->fp, "%d ", (unsigned char) value) > 0;
+    if (value > PLY_UINT8_MAX || value < 0) return 0;
+    return fprintf(ply->fp, "%d", (t_ply_uint8) value) > 0;
 }
 
 static int oascii_int16(p_ply ply, double value) {
-    if (value > SHRT_MAX || value < SHRT_MIN) return 0;
-    return fprintf(ply->fp, "%d ", (short) value) > 0;
+    if (value > PLY_INT16_MAX || value < PLY_INT16_MIN) return 0;
+    return fprintf(ply->fp, "%d", (t_ply_int16) value) > 0;
 }
 
 static int oascii_uint16(p_ply ply, double value) {
-    if (value > USHRT_MAX || value < 0) return 0;
-    return fprintf(ply->fp, "%d ", (unsigned short) value) > 0;
+    if (value > PLY_UINT16_MAX || value < 0) return 0;
+    return fprintf(ply->fp, "%d", (t_ply_uint16) value) > 0;
 }
 
 static int oascii_int32(p_ply ply, double value) {
-    if (value > INT_MAX || value < INT_MIN) return 0;
-    return fprintf(ply->fp, "%d ", (int) value) > 0;
+    if (value > PLY_INT32_MAX || value < PLY_INT32_MIN) return 0;
+    return fprintf(ply->fp, "%d", (t_ply_int32) value) > 0;
 }
 
 static int oascii_uint32(p_ply ply, double value) {
-    if (value > UINT_MAX || value < 0) return 0;
-    return fprintf(ply->fp, "%d ", (unsigned int) value) > 0;
+    if (value > PLY_UINT32_MAX || value < 0) return 0;
+    return fprintf(ply->fp, "%d", (t_ply_uint32) value) > 0;
 }
 
 static int oascii_float32(p_ply ply, double value) {
     if (value < -FLT_MAX || value > FLT_MAX) return 0;
-    return fprintf(ply->fp, "%g ", (float) value) > 0;
+    return fprintf(ply->fp, "%g", (float) value) > 0;
 }
 
 static int oascii_float64(p_ply ply, double value) {
     if (value < -DBL_MAX || value > DBL_MAX) return 0;
-    return fprintf(ply->fp, "%g ", value) > 0;
+    return fprintf(ply->fp, "%g", value) > 0;
 }
 
 static int obinary_int8(p_ply ply, double value) {
-    char int8 = (char) value;
-    if (value > CHAR_MAX || value < CHAR_MIN) return 0;
+    t_ply_int8 int8 = (t_ply_int8) value;
+    if (value > PLY_INT8_MAX || value < PLY_INT8_MIN) return 0;
     return ply->odriver->ochunk(ply, &int8, sizeof(int8));
 }
 
 static int obinary_uint8(p_ply ply, double value) {
-    unsigned char uint8 = (unsigned char) value;
-    if (value > UCHAR_MAX || value < 0) return 0;
-    return ply->odriver->ochunk(ply, &uint8, sizeof(uint8)); 
+    t_ply_uint8 uint8 = (t_ply_uint8) value;
+    if (value > PLY_UINT8_MAX || value < 0) return 0;
+    return ply->odriver->ochunk(ply, &uint8, sizeof(uint8));
 }
 
 static int obinary_int16(p_ply ply, double value) {
-    short int16 = (short) value;
-    if (value > SHRT_MAX || value < SHRT_MIN) return 0;
+    t_ply_int16 int16 = (t_ply_int16) value;
+    if (value > PLY_INT16_MAX || value < PLY_INT16_MIN) return 0;
     return ply->odriver->ochunk(ply, &int16, sizeof(int16));
 }
 
 static int obinary_uint16(p_ply ply, double value) {
-    unsigned short uint16 = (unsigned short) value;
-    if (value > USHRT_MAX || value < 0) return 0;
-    return ply->odriver->ochunk(ply, &uint16, sizeof(uint16)); 
+    t_ply_uint16 uint16 = (t_ply_uint16) value;
+    if (value > PLY_UINT16_MAX || value < 0) return 0;
+    return ply->odriver->ochunk(ply, &uint16, sizeof(uint16));
 }
 
 static int obinary_int32(p_ply ply, double value) {
-    int int32 = (int) value;
-    if (value > INT_MAX || value < INT_MIN) return 0;
+    t_ply_int32 int32 = (t_ply_int32) value;
+    if (value > PLY_INT32_MAX || value < PLY_INT32_MIN) return 0;
     return ply->odriver->ochunk(ply, &int32, sizeof(int32));
 }
 
 static int obinary_uint32(p_ply ply, double value) {
-    unsigned int uint32 = (unsigned int) value;
-    if (value > UINT_MAX || value < 0) return 0;
+    t_ply_uint32 uint32 = (t_ply_uint32) value;
+    if (value > PLY_UINT32_MAX || value < 0) return 0;
     return ply->odriver->ochunk(ply, &uint32, sizeof(uint32));
 }
 
@@ -1286,7 +1406,7 @@ static int obinary_float32(p_ply ply, double value) {
 }
 
 static int obinary_float64(p_ply ply, double value) {
-    return ply->odriver->ochunk(ply, &value, sizeof(value)); 
+    return ply->odriver->ochunk(ply, &value, sizeof(value));
 }
 
 /* ----------------------------------------------------------------------
@@ -1296,7 +1416,7 @@ static int iascii_int8(p_ply ply, double *value) {
     char *end;
     if (!ply_read_word(ply)) return 0;
     *value = strtol(BWORD(ply), &end, 10);
-    if (*end || *value > CHAR_MAX || *value < CHAR_MIN) return 0;
+    if (*end || *value > PLY_INT8_MAX || *value < PLY_INT8_MIN) return 0;
     return 1;
 }
 
@@ -1304,7 +1424,7 @@ static int iascii_uint8(p_ply ply, double *value) {
     char *end;
     if (!ply_read_word(ply)) return 0;
     *value = strtol(BWORD(ply), &end, 10);
-    if (*end || *value > UCHAR_MAX || *value < 0) return 0;
+    if (*end || *value > PLY_UINT8_MAX || *value < 0) return 0;
     return 1;
 }
 
@@ -1312,7 +1432,7 @@ static int iascii_int16(p_ply ply, double *value) {
     char *end;
     if (!ply_read_word(ply)) return 0;
     *value = strtol(BWORD(ply), &end, 10);
-    if (*end || *value > SHRT_MAX || *value < SHRT_MIN) return 0;
+    if (*end || *value > PLY_INT16_MAX || *value < PLY_INT16_MIN) return 0;
     return 1;
 }
 
@@ -1320,7 +1440,7 @@ static int iascii_uint16(p_ply ply, double *value) {
     char *end;
     if (!ply_read_word(ply)) return 0;
     *value = strtol(BWORD(ply), &end, 10);
-    if (*end || *value > USHRT_MAX || *value < 0) return 0;
+    if (*end || *value > PLY_UINT16_MAX || *value < 0) return 0;
     return 1;
 }
 
@@ -1328,7 +1448,7 @@ static int iascii_int32(p_ply ply, double *value) {
     char *end;
     if (!ply_read_word(ply)) return 0;
     *value = strtol(BWORD(ply), &end, 10);
-    if (*end || *value > INT_MAX || *value < INT_MIN) return 0;
+    if (*end || *value > PLY_INT32_MAX || *value < PLY_INT32_MIN) return 0;
     return 1;
 }
 
@@ -1336,7 +1456,7 @@ static int iascii_uint32(p_ply ply, double *value) {
     char *end;
     if (!ply_read_word(ply)) return 0;
     *value = strtol(BWORD(ply), &end, 10);
-    if (*end || *value < 0) return 0;
+    if (*end || *value > PLY_UINT32_MAX || *value < 0) return 0;
     return 1;
 }
 
@@ -1357,42 +1477,42 @@ static int iascii_float64(p_ply ply, double *value) {
 }
 
 static int ibinary_int8(p_ply ply, double *value) {
-    char int8;
+    t_ply_int8 int8;
     if (!ply->idriver->ichunk(ply, &int8, 1)) return 0;
     *value = int8;
     return 1;
 }
 
 static int ibinary_uint8(p_ply ply, double *value) {
-    unsigned char uint8;
+    t_ply_uint8 uint8;
     if (!ply->idriver->ichunk(ply, &uint8, 1)) return 0;
     *value = uint8;
     return 1;
 }
 
 static int ibinary_int16(p_ply ply, double *value) {
-    short int16;
+    t_ply_int16 int16;
     if (!ply->idriver->ichunk(ply, &int16, sizeof(int16))) return 0;
     *value = int16;
     return 1;
 }
 
 static int ibinary_uint16(p_ply ply, double *value) {
-    unsigned short uint16;
+    t_ply_uint16 uint16;
     if (!ply->idriver->ichunk(ply, &uint16, sizeof(uint16))) return 0;
     *value = uint16;
     return 1;
 }
 
 static int ibinary_int32(p_ply ply, double *value) {
-    int int32;
+    t_ply_int32 int32;
     if (!ply->idriver->ichunk(ply, &int32, sizeof(int32))) return 0;
     *value = int32;
     return 1;
 }
 
 static int ibinary_uint32(p_ply ply, double *value) {
-    unsigned int uint32;
+    t_ply_uint32 uint32;
     if (!ply->idriver->ichunk(ply, &uint32, sizeof(uint32))) return 0;
     *value = uint32;
     return 1;
@@ -1402,7 +1522,6 @@ static int ibinary_float32(p_ply ply, double *value) {
     float float32;
     if (!ply->idriver->ichunk(ply, &float32, sizeof(float32))) return 0;
     *value = float32;
-    ply_reverse(&float32, sizeof(float32));
     return 1;
 }
 
@@ -1474,7 +1593,7 @@ static t_ply_odriver ply_odriver_binary_reverse = {
 };
 
 /* ----------------------------------------------------------------------
- * Copyright (C) 2003 Diego Nehab.  All rights reserved.
+ * Copyright (C) 2003-2015 Diego Nehab.  All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/rply/rply.h
+++ b/tools/rply/rply.h
@@ -1,9 +1,9 @@
-#ifndef PLY_H
-#define PLY_H
+#ifndef RPLY_H
+#define RPLY_H
 /* ----------------------------------------------------------------------
  * RPly library, read/write PLY files
- * Diego Nehab, Princeton University
- * http://www.cs.princeton.edu/~diego/professional/rply
+ * Diego Nehab, IMPA
+ * http://www.impa.br/~diego/software/rply
  *
  * This library is distributed under the MIT License. See notice
  * at the end of this file.
@@ -13,8 +13,8 @@
 extern "C" {
 #endif
 
-#define RPLY_VERSION   "RPly 1.01"
-#define RPLY_COPYRIGHT "Copyright (C) 2003-2005 Diego Nehab"
+#define RPLY_VERSION   "RPly 1.1.4"
+#define RPLY_COPYRIGHT "Copyright (C) 2003-2015 Diego Nehab"
 #define RPLY_AUTHORS   "Diego Nehab"
 
 /* ----------------------------------------------------------------------
@@ -30,13 +30,13 @@ typedef struct t_ply_argument_ *p_ply_argument;
 typedef enum e_ply_storage_mode_ {
     PLY_BIG_ENDIAN,
     PLY_LITTLE_ENDIAN,
-    PLY_ASCII,   
+    PLY_ASCII,
     PLY_DEFAULT      /* has to be the last in enum */
 } e_ply_storage_mode; /* order matches ply_storage_mode_list */
 
 /* ply data type */
 typedef enum e_ply_type {
-    PLY_INT8, PLY_UINT8, PLY_INT16, PLY_UINT16, 
+    PLY_INT8, PLY_UINT8, PLY_INT16, PLY_UINT16,
     PLY_INT32, PLY_UIN32, PLY_FLOAT32, PLY_FLOAT64,
     PLY_CHAR, PLY_UCHAR, PLY_SHORT, PLY_USHORT,
     PLY_INT, PLY_UINT, PLY_FLOAT, PLY_DOUBLE,
@@ -44,24 +44,35 @@ typedef enum e_ply_type {
 } e_ply_type;   /* order matches ply_type_list */
 
 /* ----------------------------------------------------------------------
- * Property reading callback prototype
+ * Error callback prototype
  *
  * message: error message
+ * ply: handle returned by ply_open or ply_create
  * ---------------------------------------------------------------------- */
-typedef void (*p_ply_error_cb)(const char *message);
+typedef void (*p_ply_error_cb)(p_ply ply, const char *message);
 
 /* ----------------------------------------------------------------------
- * Opens a ply file for reading (fails if file is not a ply file)
+ * Gets user data from within an error callback
  *
- * error_cb: error callback function
+ * ply: handle returned by ply_open or ply_create
+ * idata,pdata: contextual information set in ply_open or ply_create
+ * ---------------------------------------------------------------------- */
+int ply_get_ply_user_data(p_ply ply, void **pdata, long *idata);
+
+/* ----------------------------------------------------------------------
+ * Opens a PLY file for reading (fails if file is not a PLY file)
+ *
  * name: file name
+ * error_cb: error callback function
+ * idata,pdata: contextual information available to users
  *
  * Returns 1 if successful, 0 otherwise
  * ---------------------------------------------------------------------- */
-p_ply ply_open(const char *name, p_ply_error_cb error_cb);
+p_ply ply_open(const char *name, p_ply_error_cb error_cb, long idata,
+        void *pdata);
 
 /* ----------------------------------------------------------------------
- * Reads and parses the header of a ply file returned by ply_open
+ * Reads and parses the header of a PLY file returned by ply_open
  *
  * ply: handle returned by ply_open
  *
@@ -88,57 +99,57 @@ typedef int (*p_ply_read_cb)(p_ply_argument argument);
  * pdata/idata: user data that will be passed to callback
  *
  * Returns 0 if no element or no property in element, returns the
- * number of element instances otherwise. 
+ * number of element instances otherwise.
  * ---------------------------------------------------------------------- */
-long ply_set_read_cb(p_ply ply, const char *element_name, 
-        const char *property_name, p_ply_read_cb read_cb, 
+long ply_set_read_cb(p_ply ply, const char *element_name,
+        const char *property_name, p_ply_read_cb read_cb,
         void *pdata, long idata);
 
 /* ----------------------------------------------------------------------
  * Returns information about the element originating a callback
  *
- * argument: handle to argument 
+ * argument: handle to argument
  * element: receives a the element handle (if non-null)
- * instance_index: receives the index of the current element instance 
+ * instance_index: receives the index of the current element instance
  *     (if non-null)
  *
  * Returns 1 if successfull, 0 otherwise
  * ---------------------------------------------------------------------- */
-int ply_get_argument_element(p_ply_argument argument, 
+int ply_get_argument_element(p_ply_argument argument,
         p_ply_element *element, long *instance_index);
 
 /* ----------------------------------------------------------------------
  * Returns information about the property originating a callback
  *
- * argument: handle to argument 
+ * argument: handle to argument
  * property: receives the property handle (if non-null)
  * length: receives the number of values in this property (if non-null)
  * value_index: receives the index of current property value (if non-null)
  *
  * Returns 1 if successfull, 0 otherwise
  * ---------------------------------------------------------------------- */
-int ply_get_argument_property(p_ply_argument argument, 
+int ply_get_argument_property(p_ply_argument argument,
         p_ply_property *property, long *length, long *value_index);
 
 /* ----------------------------------------------------------------------
- * Returns user data associated with callback 
+ * Returns user data associated with callback
  *
  * pdata: receives a copy of user custom data pointer (if non-null)
  * idata: receives a copy of user custom data integer (if non-null)
  *
  * Returns 1 if successfull, 0 otherwise
  * ---------------------------------------------------------------------- */
-int ply_get_argument_user_data(p_ply_argument argument, void **pdata, 
+int ply_get_argument_user_data(p_ply_argument argument, void **pdata,
         long *idata);
 
 /* ----------------------------------------------------------------------
  * Returns the value associated with a callback
  *
- * argument: handle to argument 
+ * argument: handle to argument
  *
  * Returns the current data item
  * ---------------------------------------------------------------------- */
-double ply_get_argument_value(p_ply_argument argument); 
+double ply_get_argument_value(p_ply_argument argument);
 
 /* ----------------------------------------------------------------------
  * Reads all elements and properties calling the callbacks defined with
@@ -204,7 +215,7 @@ int ply_get_element_info(p_ply_element element, const char** name,
  *
  * Returns element if successfull or NULL if no more properties
  * ---------------------------------------------------------------------- */
-p_ply_property ply_get_next_property(p_ply_element element, 
+p_ply_property ply_get_next_property(p_ply_element element,
         p_ply_property last);
 
 /* ----------------------------------------------------------------------
@@ -215,7 +226,7 @@ p_ply_property ply_get_next_property(p_ply_element element,
  * type: receives the property type (if non-null)
  * length_type: for list properties, receives the scalar type of
  *     the length field (if non-null)
- * value_type: for list properties, receives the scalar type of the value 
+ * value_type: for list properties, receives the scalar type of the value
  *     fields  (if non-null)
  *
  * Returns 1 if successfull or 0 otherwise
@@ -224,18 +235,20 @@ int ply_get_property_info(p_ply_property property, const char** name,
         e_ply_type *type, e_ply_type *length_type, e_ply_type *value_type);
 
 /* ----------------------------------------------------------------------
- * Creates new ply file
+ * Creates new PLY file
  *
  * name: file name
  * storage_mode: file format mode
+ * error_cb: error callback function
+ * idata,pdata: contextual information available to users
  *
- * Returns handle to ply file if successfull, NULL otherwise
+ * Returns handle to PLY file if successfull, NULL otherwise
  * ---------------------------------------------------------------------- */
-p_ply ply_create(const char *name, e_ply_storage_mode storage_mode, 
-        p_ply_error_cb error_cb);
+p_ply ply_create(const char *name, e_ply_storage_mode storage_mode,
+        p_ply_error_cb error_cb, long idata, void *pdata);
 
 /* ----------------------------------------------------------------------
- * Adds a new element to the ply file created by ply_create
+ * Adds a new element to the PLY file created by ply_create
  *
  * ply: handle returned by ply_create
  * name: name of new element
@@ -251,7 +264,7 @@ int ply_add_element(p_ply ply, const char *name, long ninstances);
  * ply: handle returned by ply_create
  * name: name of new property
  * type: property type
- * length_type: scalar type of length field of a list property 
+ * length_type: scalar type of length field of a list property
  * value_type: scalar type of value fields of a list property
  *
  * Returns 1 if successfull, 0 otherwise
@@ -264,12 +277,12 @@ int ply_add_property(p_ply ply, const char *name, e_ply_type type,
  *
  * ply: handle returned by ply_create
  * name: name of new property
- * length_type: scalar type of length field of a list property 
+ * length_type: scalar type of length field of a list property
  * value_type: scalar type of value fields of a list property
  *
  * Returns 1 if successfull, 0 otherwise
  * ---------------------------------------------------------------------- */
-int ply_add_list_property(p_ply ply, const char *name, 
+int ply_add_list_property(p_ply ply, const char *name,
         e_ply_type length_type, e_ply_type value_type);
 
 /* ----------------------------------------------------------------------
@@ -284,7 +297,7 @@ int ply_add_list_property(p_ply ply, const char *name,
 int ply_add_scalar_property(p_ply ply, const char *name, e_ply_type type);
 
 /* ----------------------------------------------------------------------
- * Adds a new comment item 
+ * Adds a new comment item
  *
  * ply: handle returned by ply_create
  * comment: pointer to string with comment text
@@ -294,7 +307,7 @@ int ply_add_scalar_property(p_ply ply, const char *name, e_ply_type type);
 int ply_add_comment(p_ply ply, const char *comment);
 
 /* ----------------------------------------------------------------------
- * Adds a new obj_info item 
+ * Adds a new obj_info item
  *
  * ply: handle returned by ply_create
  * comment: pointer to string with obj_info data
@@ -304,7 +317,7 @@ int ply_add_comment(p_ply ply, const char *comment);
 int ply_add_obj_info(p_ply ply, const char *obj_info);
 
 /* ----------------------------------------------------------------------
- * Writes the ply file header after all element and properties have been
+ * Writes the PLY file header after all element and properties have been
  * defined by calls to ply_add_element and ply_add_property
  *
  * ply: handle returned by ply_create
@@ -317,7 +330,7 @@ int ply_write_header(p_ply ply);
  * Writes one property value, in the order they should be written to the
  * file. For each element type, write all elements of that type in order.
  * For each element, write all its properties in order. For scalar
- * properties, just write the value. For list properties, write the length 
+ * properties, just write the value. For list properties, write the length
  * and then each of the values.
  *
  * ply: handle returned by ply_create
@@ -327,9 +340,9 @@ int ply_write_header(p_ply ply);
 int ply_write(p_ply ply, double value);
 
 /* ----------------------------------------------------------------------
- * Closes a ply file handle. Releases all memory used by handle
+ * Closes a PLY file handle. Releases all memory used by handle
  *
- * ply: handle to be closed. 
+ * ply: handle to be closed.
  *
  * Returns 1 if successfull, 0 otherwise
  * ---------------------------------------------------------------------- */
@@ -342,7 +355,7 @@ int ply_close(p_ply ply);
 #endif /* RPLY_H */
 
 /* ----------------------------------------------------------------------
- * Copyright (C) 2003-2005 Diego Nehab. All rights reserved.
+ * Copyright (C) 2003-2015 Diego Nehab. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the


### PR DESCRIPTION
Update the bundled copy of rply from 1.01 to 1.1.4, and adapt the call to `ply_open()` in `ply.cpp`.

(I am considering packaging this for Fedora Linux, and I would want to build it [using an external/system copy of the rply library rather than with the bundled copy](https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling). API-compatibility with the current release is a prerequisite for that.)