### PR TITLE
Make the Makefile.linux build system flexible enough for distribution packaging

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -47,6 +47,7 @@ documentation:
 
 
 # Installation settings
+DESTDIR =
 LIBDIR  = /usr/lib/
 INCDIR  = /usr/local/include/
 BINDIR  = /usr/local/bin/
@@ -55,14 +56,14 @@ CP = cp
 MKDIR = mkdir -p
 
 install:
-	$(MKDIR) $(LIBDIR)
-	$(CP) lib/libopenctm.so $(LIBDIR)
-	$(MKDIR) $(INCDIR)
-	$(CP) lib/openctm.h $(INCDIR)
-	$(CP) lib/openctmpp.h $(INCDIR)
-	$(MKDIR) $(BINDIR)
-	$(CP) tools/ctmconv $(BINDIR)
-	$(CP) tools/ctmviewer $(BINDIR)
-	$(MKDIR) $(MAN1DIR)
-	$(CP) doc/ctmconv.1 $(MAN1DIR)
-	$(CP) doc/ctmviewer.1 $(MAN1DIR)
+	$(MKDIR) $(DESTDIR)$(LIBDIR)
+	$(CP) lib/libopenctm.so $(DESTDIR)$(LIBDIR)
+	$(MKDIR) $(DESTDIR)$(INCDIR)
+	$(CP) lib/openctm.h $(DESTDIR)$(INCDIR)
+	$(CP) lib/openctmpp.h $(DESTDIR)$(INCDIR)
+	$(MKDIR) $(DESTDIR)$(BINDIR)
+	$(CP) tools/ctmconv $(DESTDIR)$(BINDIR)
+	$(CP) tools/ctmviewer $(DESTDIR)$(BINDIR)
+	$(MKDIR) $(DESTDIR)$(MAN1DIR)
+	$(CP) doc/ctmconv.1 $(DESTDIR)$(MAN1DIR)
+	$(CP) doc/ctmviewer.1 $(DESTDIR)$(MAN1DIR)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -57,7 +57,7 @@ MKDIR = mkdir -p
 
 install:
 	$(MKDIR) $(DESTDIR)$(LIBDIR)
-	$(CP) lib/libopenctm.so $(DESTDIR)$(LIBDIR)
+	$(CP) -P lib/libopenctm.so* $(DESTDIR)$(LIBDIR)
 	$(MKDIR) $(DESTDIR)$(INCDIR)
 	$(CP) lib/openctm.h $(DESTDIR)$(INCDIR)
 	$(CP) lib/openctmpp.h $(DESTDIR)$(INCDIR)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -55,9 +55,12 @@ CP = cp
 MKDIR = mkdir -p
 
 install:
+	$(MKDIR) $(LIBDIR)
 	$(CP) lib/libopenctm.so $(LIBDIR)
+	$(MKDIR) $(INCDIR)
 	$(CP) lib/openctm.h $(INCDIR)
 	$(CP) lib/openctmpp.h $(INCDIR)
+	$(MKDIR) $(BINDIR)
 	$(CP) tools/ctmconv $(BINDIR)
 	$(CP) tools/ctmviewer $(BINDIR)
 	$(MKDIR) $(MAN1DIR)

--- a/lib/Makefile.linux
+++ b/lib/Makefile.linux
@@ -30,6 +30,8 @@ LZMADIR = liblzma
 CC = gcc
 CFLAGS = -O3 -W -Wall -c -fPIC -DOPENCTM_BUILD -I$(LZMADIR) -DLZMA_PREFIX_CTM -std=c99 -pedantic
 CFLAGS_LZMA = -O3 -W -Wall -c -fPIC -DLZMA_PREFIX_CTM -std=c99 -pedantic
+LDFLAGS = -s
+DYNAMICLIBLDFLAGS = -lm $(LDFLAGS)
 RM = rm -f
 DEPEND = $(CPP) -MM
 
@@ -71,7 +73,7 @@ clean:
 	$(RM) $(DYNAMICLIB) $(DYNAMICLIBLINK) $(OBJS) $(LZMA_OBJS)
 
 $(DYNAMICLIB): $(OBJS) $(LZMA_OBJS)
-	gcc -shared -s -Wl,-soname,$@ -o $@ $(OBJS) $(LZMA_OBJS) -lm
+	gcc -shared -Wl,-soname,$@ -o $@ $(OBJS) $(LZMA_OBJS) $(DYNAMICLIBLDFLAGS)
 
 $(DYNAMICLIBLINK): $(DYNAMICLIB)
 	ln -s -f $< $@

--- a/lib/Makefile.linux
+++ b/lib/Makefile.linux
@@ -33,7 +33,11 @@ CFLAGS_LZMA = -O3 -W -Wall -c -fPIC -DLZMA_PREFIX_CTM -std=c99 -pedantic
 RM = rm -f
 DEPEND = $(CPP) -MM
 
-DYNAMICLIB = libopenctm.so
+# Increment whenever there is a backwards-incompatible ABI change
+ABI_VERSION = 1
+
+DYNAMICLIB = libopenctm.so.$(ABI_VERSION)
+DYNAMICLIBLINK = libopenctm.so
 
 OBJS = openctm.o \
        stream.o \
@@ -61,13 +65,16 @@ LZMA_SRCS = $(LZMADIR)/Alloc.c \
 
 .phony: all clean depend
 
-all: $(DYNAMICLIB)
+all: $(DYNAMICLIB) $(DYNAMICLIBLINK)
 
 clean:
-	$(RM) $(DYNAMICLIB) $(OBJS) $(LZMA_OBJS)
+	$(RM) $(DYNAMICLIB) $(DYNAMICLIBLINK) $(OBJS) $(LZMA_OBJS)
 
 $(DYNAMICLIB): $(OBJS) $(LZMA_OBJS)
 	gcc -shared -s -Wl,-soname,$@ -o $@ $(OBJS) $(LZMA_OBJS) -lm
+
+$(DYNAMICLIBLINK): $(DYNAMICLIB)
+	ln -s -f $< $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) $<

--- a/lib/Makefile.linux
+++ b/lib/Makefile.linux
@@ -28,8 +28,9 @@
 
 LZMADIR = liblzma
 CC = gcc
-CFLAGS = -O3 -W -Wall -c -fPIC -DOPENCTM_BUILD -I$(LZMADIR) -DLZMA_PREFIX_CTM -std=c99 -pedantic
-CFLAGS_LZMA = -O3 -W -Wall -c -fPIC -DLZMA_PREFIX_CTM -std=c99 -pedantic
+CFLAGS = -O3 -W -Wall -fPIC -std=c99 -pedantic
+CFLAGS_LIB = -DOPENCTM_BUILD -DLZMA_PREFIX_CTM -I$(LZMADIR)
+CFLAGS_LZMA = -DLZMA_PREFIX_CTM
 LDFLAGS = -s
 DYNAMICLIBLDFLAGS = -lm $(LDFLAGS)
 RM = rm -f
@@ -79,10 +80,10 @@ $(DYNAMICLIBLINK): $(DYNAMICLIB)
 	ln -s -f $< $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $<
+	$(CC) -c $(CFLAGS) $(CFLAGS_LIB) $<
 
 %.o: $(LZMADIR)/%.c
-	$(CC) $(CFLAGS_LZMA) $<
+	$(CC) -c $(CFLAGS) $(CFLAGS_LZMA) $<
 
 depend:
 	$(DEPEND) $(SRCS) $(LZMA_SRCS) > make.depend

--- a/tools/Makefile.linux
+++ b/tools/Makefile.linux
@@ -34,7 +34,8 @@ ZLIBDIR = zlib
 PNGLITEDIR = pnglite
 
 CPP = g++
-CPPFLAGS = -c -O3 -W -Wall `pkg-config --cflags gtk+-2.0` -I$(OPENCTMDIR) -I$(RPLYDIR) -I$(JPEGDIR) -I$(TINYXMLDIR) -I$(GLEWDIR) -I$(ZLIBDIR) -I$(PNGLITEDIR)
+CPPFLAGS = -O3 -W -Wall
+CPPFLAGS_INCLUDE = `pkg-config --cflags gtk+-2.0` -I$(OPENCTMDIR) -I$(RPLYDIR) -I$(JPEGDIR) -I$(TINYXMLDIR) -I$(GLEWDIR) -I$(ZLIBDIR) -I$(PNGLITEDIR)
 
 LDFLAGS = -s -Wl,-rpath,.
 CTMCONVLDFLAGS = -L$(OPENCTMDIR) -L$(TINYXMLDIR)
@@ -71,7 +72,7 @@ ctmbench: $(CTMBENCHOBJS) libopenctm.so
 	$(CPP) -o $@ $(CTMBENCHLDFLAGS) $(CTMBENCHOBJS) $(LDFLAGS) $(CTMBENCHLIBS)
 
 %.o: %.cpp
-	$(CPP) $(CPPFLAGS) -o $@ $<
+	$(CPP) -c $(CPPFLAGS) $(CPPFLAGS_INCLUDE) -o $@ $<
 
 ctmconv.o: ctmconv.cpp systimer.h convoptions.h mesh.h meshio.h
 ctmviewer.o: ctmviewer.cpp common.h image.h systimer.h sysdialog.h mesh.h meshio.h phong_vert.h phong_frag.h icons/icon_open.h icons/icon_save.h icons/icon_help.h

--- a/tools/Makefile.linux
+++ b/tools/Makefile.linux
@@ -36,6 +36,15 @@ PNGLITEDIR = pnglite
 CPP = g++
 CPPFLAGS = -c -O3 -W -Wall `pkg-config --cflags gtk+-2.0` -I$(OPENCTMDIR) -I$(RPLYDIR) -I$(JPEGDIR) -I$(TINYXMLDIR) -I$(GLEWDIR) -I$(ZLIBDIR) -I$(PNGLITEDIR)
 
+LDFLAGS = -s -Wl,-rpath,.
+CTMCONVLDFLAGS = -L$(OPENCTMDIR) -L$(TINYXMLDIR)
+CTMVIEWERLDFLAGS = -L$(OPENCTMDIR) -L$(TINYXMLDIR) -L$(JPEGDIR) -L$(ZLIBDIR)
+CTMBENCHLDFLAGS = -L$(OPENCTMDIR)
+
+CTMCONVLIBS = -lopenctm -ltinyxml
+CTMVIEWERLIBS = -lopenctm -ltinyxml -ljpeg -lz -lglut -lGL -lGLU `pkg-config --libs gtk+-2.0`
+CTMBENCHLIBS = -lopenctm
+
 MESHOBJS = mesh.o meshio.o ctm.o ply.o rply.o stl.o 3ds.o dae.o obj.o lwo.o off.o wrl.o
 CTMCONVOBJS = ctmconv.o common.o systimer.o convoptions.o $(MESHOBJS)
 CTMVIEWEROBJS = ctmviewer.o common.o image.o systimer.o sysdialog_gtk.o convoptions.o glew.o pnglite.o $(MESHOBJS)
@@ -53,13 +62,13 @@ libopenctm.so: $(OPENCTMDIR)/libopenctm.so
 	cp $< $@
 
 ctmconv: $(CTMCONVOBJS) $(TINYXMLDIR)/libtinyxml.a libopenctm.so
-	$(CPP) -s -o $@ -L$(OPENCTMDIR) -L$(TINYXMLDIR) $(CTMCONVOBJS) -Wl,-rpath,. -lopenctm -ltinyxml
+	$(CPP) -o $@ $(CTMCONVLDFLAGS) $(CTMCONVOBJS) $(LDFLAGS) $(CTMCONVLIBS)
 
 ctmviewer: $(CTMVIEWEROBJS) $(JPEGDIR)/libjpeg.a $(TINYXMLDIR)/libtinyxml.a $(ZLIBDIR)/libz.a libopenctm.so
-	$(CPP) -s -o $@ -L$(OPENCTMDIR) -L$(TINYXMLDIR) -L$(JPEGDIR) -L$(ZLIBDIR) $(CTMVIEWEROBJS) -Wl,-rpath,. -lopenctm -ltinyxml -ljpeg -lz -lglut -lGL -lGLU `pkg-config --libs gtk+-2.0`
+	$(CPP) -o $@ $(CTMVIEWERLDFLAGS) $(CTMVIEWEROBJS) $(LDFLAGS) $(CTMVIEWERLIBS)
 
 ctmbench: $(CTMBENCHOBJS) libopenctm.so
-	$(CPP) -s -o $@ -L$(OPENCTMDIR) $(CTMBENCHOBJS) -Wl,-rpath,. -lopenctm
+	$(CPP) -o $@ $(CTMBENCHLDFLAGS) $(CTMBENCHOBJS) $(LDFLAGS) $(CTMBENCHLIBS)
 
 %.o: %.cpp
 	$(CPP) $(CPPFLAGS) -o $@ $<

--- a/tools/Makefile.linux
+++ b/tools/Makefile.linux
@@ -46,10 +46,17 @@ CTMCONVLIBS = -lopenctm -ltinyxml
 CTMVIEWERLIBS = -lopenctm -ltinyxml -ljpeg -lz -lglut -lGL -lGLU `pkg-config --libs gtk+-2.0`
 CTMBENCHLIBS = -lopenctm
 
-MESHOBJS = mesh.o meshio.o ctm.o ply.o rply.o stl.o 3ds.o dae.o obj.o lwo.o off.o wrl.o
+RPLYOBJS = rply.o
+PNGLITEOBJS = pnglite.o
+GLEWOBJS = glew.o
+MESHOBJS = mesh.o meshio.o ctm.o ply.o $(RPLYOBJS) stl.o 3ds.o dae.o obj.o lwo.o off.o wrl.o
 CTMCONVOBJS = ctmconv.o common.o systimer.o convoptions.o $(MESHOBJS)
-CTMVIEWEROBJS = ctmviewer.o common.o image.o systimer.o sysdialog_gtk.o convoptions.o glew.o pnglite.o $(MESHOBJS)
+CTMVIEWEROBJS = ctmviewer.o common.o image.o systimer.o sysdialog_gtk.o convoptions.o $(GLEWOBJS) $(PNGLITEOBJS) $(MESHOBJS)
 CTMBENCHOBJS = ctmbench.o systimer.o
+
+ZLIBSTATIC = $(ZLIBDIR)/libz.a
+JPEGSTATIC = $(JPEGDIR)/libjpeg.a
+TINYXMLSTATIC = $(JPEGDIR)/libtinyxml.a
 
 all: ctmconv ctmviewer ctmbench
 
@@ -62,10 +69,10 @@ clean:
 libopenctm.so: $(OPENCTMDIR)/libopenctm.so
 	cp $< $@
 
-ctmconv: $(CTMCONVOBJS) $(TINYXMLDIR)/libtinyxml.a libopenctm.so
+ctmconv: $(CTMCONVOBJS) $(TINYXMLSTATIC) libopenctm.so
 	$(CPP) -o $@ $(CTMCONVLDFLAGS) $(CTMCONVOBJS) $(LDFLAGS) $(CTMCONVLIBS)
 
-ctmviewer: $(CTMVIEWEROBJS) $(JPEGDIR)/libjpeg.a $(TINYXMLDIR)/libtinyxml.a $(ZLIBDIR)/libz.a libopenctm.so
+ctmviewer: $(CTMVIEWEROBJS) $(JPEGSTATIC) $(TINYXMLSTATIC) $(ZLIBSTATIC) libopenctm.so
 	$(CPP) -o $@ $(CTMVIEWERLDFLAGS) $(CTMVIEWEROBJS) $(LDFLAGS) $(CTMVIEWERLIBS)
 
 ctmbench: $(CTMBENCHOBJS) libopenctm.so
@@ -78,7 +85,7 @@ ctmconv.o: ctmconv.cpp systimer.h convoptions.h mesh.h meshio.h
 ctmviewer.o: ctmviewer.cpp common.h image.h systimer.h sysdialog.h mesh.h meshio.h phong_vert.h phong_frag.h icons/icon_open.h icons/icon_save.h icons/icon_help.h
 ctmbench.o: ctmbench.cpp systimer.h
 common.o: common.cpp common.h
-image.o: image.cpp image.h common.h $(JPEGDIR)/libjpeg.a
+image.o: image.cpp image.h common.h $(JPEGSTATIC)
 systimer.o: systimer.cpp systimer.h
 sysdialog_gtk.o: sysdialog_gtk.cpp sysdialog.h
 convoptions.o: convoptions.cpp convoptions.h
@@ -106,7 +113,7 @@ bin2c: bin2c.cpp
 $(JPEGDIR)/libjpeg.a:
 	cd $(JPEGDIR) && $(MAKE) -f makefile.linux libjpeg.a
 
-$(ZLIBDIR)/libz.a:
+$(ZLIBSTATIC):
 	cd $(ZLIBDIR) && $(MAKE) -f Makefile.linux
 
 glew.o: $(GLEWDIR)/glew.c


### PR DESCRIPTION
These changes allow me to do the following without additional patching, other than https://github.com/Danny02/OpenCTM/pull/18:

- [Link against system copies of all libraries bundled in `tools/`](https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling)
- [Respect the distribution-wide compiler and linker flags](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_compiler_flags)
- [Version the shared library](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_soname_handling), https://github.com/Danny02/OpenCTM/issues/16

(I’m not saying what’s proposed here is *beautiful*, but it seems to be *workable*.)

If development resumes at some point, and particularly if the transition to CMake is finished, it would be nice if the above needs could be supported from the beginning.