### PR TITLE
Fix out-of-bounds access when exporting an empty mesh to CTM (fix #21)

### DIFF
--- a/tools/ctm.cpp
+++ b/tools/ctm.cpp
@@ -123,8 +123,16 @@ void Export_CTM(const char * aFileName, Mesh * aMesh, Options &aOptions)
   CTMfloat * normals = 0;
   if(aMesh->HasNormals() && !aOptions.mNoNormals)
     normals = &aMesh->mNormals[0].x;
-  ctm.DefineMesh((CTMfloat *) &aMesh->mVertices[0].x, aMesh->mVertices.size(),
-                 (const CTMuint*) &aMesh->mIndices[0], aMesh->mIndices.size() / 3,
+  CTMfloat dummy_vertex = 0;
+  CTMfloat * vertices = &dummy_vertex;
+  if(aMesh->mVertices.size()>0)
+    vertices = (CTMfloat *) &aMesh->mVertices[0].x;
+  CTMuint dummy_index = 0;
+  const CTMuint * indices = &dummy_index;
+  if(aMesh->mIndices.size()>0)
+    indices = (const CTMuint*) &aMesh->mIndices[0];
+  ctm.DefineMesh(vertices, aMesh->mVertices.size(),
+                 indices, aMesh->mIndices.size() / 3,
                  normals);
 
   // Define texture coordinates


### PR DESCRIPTION
When tested as described in https://github.com/Danny02/OpenCTM/issues/21, the result is now:

```
$ LD_LIBRARY_PATH="${PWD}/lib" ./tools/ctmconv sitting.dae sitting.ctm
Loading sitting.dae... 43.327 ms
Saving sitting.ctm... Error: CTM_INVALID_ARGUMENT
```

… which is a failure, but not a crash/abort.

Maybe there is a better way this could be handled with deeper understanding.